### PR TITLE
Remove retired users when recording a match

### DIFF
--- a/app/views/matches/new.html.erb
+++ b/app/views/matches/new.html.erb
@@ -17,7 +17,7 @@
     </div>
 
     <%= form.label :player_two_id, "Who was your oppoent?" %>
-    <%= form.select :player_two_id, User.where(retired: false).everyone_else(current_user).collect { |u| ["#{u.name}", u.id] }, {include_blank: "Select Opponent"}, required: true %>
+    <%= form.select :player_two_id, User.active.everyone_else(current_user).collect { |u| ["#{u.name}", u.id] }, {include_blank: "Select Opponent"}, required: true %>
 
     <%= form.label :player_one_rounds_won, "How many rounds did you win?" %>
     <%= form.select :player_one_rounds_won, [0,1,2,3], { include_blank: "rounds won" }, required: true, id: "playerOneRoundsWon" %>

--- a/app/views/matches/new.html.erb
+++ b/app/views/matches/new.html.erb
@@ -17,7 +17,7 @@
     </div>
 
     <%= form.label :player_two_id, "Who was your oppoent?" %>
-    <%= form.select :player_two_id, User.everyone_else(current_user).collect { |u| ["#{u.name}", u.id] }, {include_blank: "Select Opponent"}, required: true %>
+    <%= form.select :player_two_id, User.where(retired: false).everyone_else(current_user).collect { |u| ["#{u.name}", u.id] }, {include_blank: "Select Opponent"}, required: true %>
 
     <%= form.label :player_one_rounds_won, "How many rounds did you win?" %>
     <%= form.select :player_one_rounds_won, [0,1,2,3], { include_blank: "rounds won" }, required: true, id: "playerOneRoundsWon" %>


### PR DESCRIPTION
Console Log:

```
Started GET "/matches/new" for 127.0.0.1 at 2018-07-04 14:01:52 -0400
Processing by MatchesController#new as HTML
  User Load (0.4ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 ORDER BY "users"."id" ASC LIMIT $2  [["id", 1], ["LIMIT", 1]]
  Rendering matches/new.html.erb within layouts/application
  Rendered shared/_errors.html.erb (0.5ms)
  User Load (0.8ms)  SELECT "users".* FROM "users" WHERE "users"."retired" = $1 AND "users"."id" != $2 ORDER BY "users"."name" ASC  [["retired", false], ["id", 1]]
  Rendered matches/new.html.erb within layouts/application (10.0ms)
   (0.4ms)  SELECT COUNT(*) FROM "matches" WHERE "matches"."winner_id" IS NULL AND "matches"."player_two_id" = $1  [["player_two_id", 1]]
Completed 200 OK in 51ms (Views: 45.7ms | ActiveRecord: 1.5ms)

```